### PR TITLE
feat: ssr other sections

### DIFF
--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -21,7 +21,7 @@ const stagger = {
 
 export function CTASection() {
   return (
-    <section className="py-20" id="pricing">
+    <section className="py-20 bg-muted/50" id="pricing">
       <div className="container px-4 mx-auto">
         <motion.div
           initial="initial"
@@ -30,17 +30,17 @@ export function CTASection() {
           variants={stagger}
           className="max-w-3xl mx-auto text-center"
         >
-          <motion.h2 variants={fadeIn} className="text-3xl font-bold mb-6">
+          <motion.h2 variants={fadeIn} className="text-3xl md:text-5xl font-bold mb-6">
             Start Collecting Reviews Today
           </motion.h2>
-          <motion.p variants={fadeIn} className="text-lg text-muted-foreground mb-8">
+          <motion.p variants={fadeIn} className="text-lg md:text-xl text-muted-foreground mb-8 px-4">
             Join thousands of businesses using Make More Reviews to grow their online presence.
           </motion.p>
-          <motion.div variants={fadeIn} className="flex gap-4 justify-center">
+          <motion.div variants={fadeIn} className="flex flex-col sm:flex-row gap-4 justify-center items-center px-4">
             <SignInModal>
               <Button
                 size="lg"
-                className="group"
+                className="group w-full sm:w-auto text-base md:min-w-[200px]"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -51,7 +51,7 @@ export function CTASection() {
             <Button
               variant="outline"
               size="lg"
-              className="group"
+              className="group w-full sm:w-auto text-base md:min-w-[200px]"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -9,6 +9,8 @@ import { UserNav } from "@/components/user-nav";
 import { useEffect, useState } from "react";
 import { createClient } from '@/lib/supabase/client';
 import { User } from '@supabase/supabase-js';
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Menu } from "lucide-react";
 
 const navItems = [
   { href: "#features", label: "Features" },
@@ -20,6 +22,7 @@ const navItems = [
 export function SiteHeader() {
   const [user, setUser] = useState<User | null>(null);
   const supabase = createClient();
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -33,6 +36,10 @@ export function SiteHeader() {
     return () => subscription.unsubscribe();
   }, []);
 
+  const handleLinkClick = () => {
+    setIsOpen(false);
+  };
+
   return (
     <motion.header
       className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
@@ -40,11 +47,13 @@ export function SiteHeader() {
       animate={{ y: 0 }}
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
     >
-      <div className="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0">
+      <div className="container flex h-16 items-center justify-between">
         <Link href="/" className="flex items-center space-x-2">
           <Logo />
         </Link>
-        <div className="flex flex-1 items-center justify-end space-x-4">
+
+        {/* Desktop Navigation */}
+        <div className="hidden md:flex items-center space-x-6">
           <nav className="flex items-center space-x-6 text-sm font-medium">
             {navItems.map((item, index) => (
               <motion.div
@@ -75,6 +84,43 @@ export function SiteHeader() {
               </SignInModal>
             )}
           </motion.div>
+        </div>
+
+        {/* Mobile Navigation */}
+        <div className="md:hidden">
+          <Sheet open={isOpen} onOpenChange={setIsOpen}>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-10 w-10">
+                <Menu className="h-6 w-6" />
+                <span className="sr-only">Toggle menu</span>
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-[280px] sm:w-[350px] pr-0">
+              <nav className="flex flex-col space-y-6 mt-6">
+                {navItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={handleLinkClick}
+                    className="text-base font-medium transition-colors hover:text-foreground/80 text-foreground/60 px-2"
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+                <div className="pt-4 px-2">
+                  {user ? (
+                    <UserNav user={user} />
+                  ) : (
+                    <SignInModal>
+                      <Button className="w-full" onClick={handleLinkClick}>
+                        Sign In
+                      </Button>
+                    </SignInModal>
+                  )}
+                </div>
+              </nav>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </motion.header>

--- a/components/ui/hero-content.tsx
+++ b/components/ui/hero-content.tsx
@@ -76,11 +76,11 @@ export function HeroContent() {
             Automate, analyze, and showcase customer feedback with Make More Reviews.
             Simplify integration and gain valuable insights.
           </motion.p>
-          <motion.div variants={fadeIn} className="flex gap-4 justify-center">
+          <motion.div variants={fadeIn} className="flex flex-col sm:flex-row gap-4 justify-center items-center">
             <SignInModal>
               <Button
                 size="lg"
-                className="group"
+                className="group w-full sm:w-auto"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -91,7 +91,7 @@ export function HeroContent() {
             <Button
               variant="outline"
               size="lg"
-              className="group bg-background/80"
+              className="group bg-background/80 w-full sm:w-auto"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >


### PR DESCRIPTION
This pull request includes several updates to improve the responsiveness and user experience of the `CTASection`, `SiteHeader`, and `HeroContent` components. The changes focus on enhancing the layout and styling for different screen sizes and adding new functionality for mobile navigation.

### Responsiveness and Styling Improvements:

* [`components/sections/cta-section.tsx`](diffhunk://#diff-62545664160f4f6e699a9159a08dd5da38fe6185cc27e8ad1589129cf72544deL24-R24): Updated the `CTASection` component to improve responsiveness by adjusting text sizes, padding, and button widths for different screen sizes. [[1]](diffhunk://#diff-62545664160f4f6e699a9159a08dd5da38fe6185cc27e8ad1589129cf72544deL24-R24) [[2]](diffhunk://#diff-62545664160f4f6e699a9159a08dd5da38fe6185cc27e8ad1589129cf72544deL33-R43) [[3]](diffhunk://#diff-62545664160f4f6e699a9159a08dd5da38fe6185cc27e8ad1589129cf72544deL54-R54)

### Mobile Navigation Enhancements:

* [`components/site-header.tsx`](diffhunk://#diff-91ead71c14ab12138135e58e3fdc2f94fd87ca1e02f3c921591e0049a27e22b1R12-R13): Added a mobile navigation drawer using the `Sheet` component, which includes navigation links and a sign-in button. This update also includes a new state to manage the drawer's open/close status. [[1]](diffhunk://#diff-91ead71c14ab12138135e58e3fdc2f94fd87ca1e02f3c921591e0049a27e22b1R12-R13) [[2]](diffhunk://#diff-91ead71c14ab12138135e58e3fdc2f94fd87ca1e02f3c921591e0049a27e22b1R25) [[3]](diffhunk://#diff-91ead71c14ab12138135e58e3fdc2f94fd87ca1e02f3c921591e0049a27e22b1R39-R56) [[4]](diffhunk://#diff-91ead71c14ab12138135e58e3fdc2f94fd87ca1e02f3c921591e0049a27e22b1R88-R124)

### Additional Responsiveness Updates:

* [`components/ui/hero-content.tsx`](diffhunk://#diff-56d28c9ae1f830d98ab9521c71d80b49ce6077927a519f3a4a9810e5c51664f5L79-R83): Improved the layout of the `HeroContent` component by making buttons responsive, ensuring they adapt to different screen sizes. [[1]](diffhunk://#diff-56d28c9ae1f830d98ab9521c71d80b49ce6077927a519f3a4a9810e5c51664f5L79-R83) [[2]](diffhunk://#diff-56d28c9ae1f830d98ab9521c71d80b49ce6077927a519f3a4a9810e5c51664f5L94-R94)